### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-auto-merge.yml` that auto-merges Dependabot PRs once CI passes, but only for **patch** and **minor** version updates. Major bumps still require manual review.
- Pairs with the repo-level settings just enabled: Dependabot alerts, automated security fixes, allow-auto-merge, delete-branch-on-merge.

## How it works
- Triggered on every `pull_request`.
- Skips immediately unless the PR author is `dependabot[bot]`.
- Uses `dependabot/fetch-metadata@v2` to read the update-type, then runs `gh pr merge --auto --squash` so GitHub merges the PR itself once required status checks pass.

## Caveats
- Auto-merge only fires after required status checks pass. Branch protection on `main` requiring the existing `build.yml` checks should be configured for this to be meaningful — otherwise Dependabot PRs merge as soon as they open.
- Major version bumps (`semver-major`) will still open a PR but will not auto-merge.

## Test plan
- [ ] Merge this PR.
- [ ] Wait for Dependabot to open security PRs (should happen within a few hours now that automated security fixes are enabled).
- [ ] Confirm patch/minor PRs land automatically; major-bump PRs stay open for review.