### PR TITLE
Tighten Dependabot auto-merge in response to npm supply-chain risk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    cooldown:
+      default-days: 7

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,8 +15,43 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for patch and minor updates
-        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+
+      - name: Check release age (manual cooldown)
+        id: cooldown
+        if: steps.meta.outputs.cve-ids != ''
+        run: |
+          set -euo pipefail
+          MIN_AGE_DAYS=7
+          # For grouped updates, dependency-names is comma-separated. Check the youngest.
+          IFS=',' read -ra PKGS <<< "${{ steps.meta.outputs.dependency-names }}"
+          version="${{ steps.meta.outputs.new-version }}"
+          youngest=99999
+          for raw in "${PKGS[@]}"; do
+            pkg=$(echo "$raw" | xargs)
+            published=$(curl -sf "https://registry.npmjs.org/${pkg}" | jq -r ".time[\"${version}\"] // empty")
+            if [ -z "$published" ]; then
+              echo "Could not look up publish date for ${pkg}@${version}; treating as too new."
+              youngest=0
+              break
+            fi
+            age=$(( ( $(date -u +%s) - $(date -u -d "$published" +%s) ) / 86400 ))
+            echo "${pkg}@${version} published ${age} days ago"
+            if [ "$age" -lt "$youngest" ]; then youngest=$age; fi
+          done
+          if [ "$youngest" -ge "$MIN_AGE_DAYS" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "Release younger than ${MIN_AGE_DAYS} days; leaving for manual review."
+          fi
+
+      - name: Enable auto-merge for security patches on direct deps
+        if: |
+          steps.meta.outputs.cve-ids != '' &&
+          steps.cooldown.outputs.ok == 'true' &&
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor') &&
+          startsWith(steps.meta.outputs.dependency-type, 'direct:')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
Narrows the auto-merge rule introduced in #26 in response to the rise of npm supply-chain attacks (xz-utils, chalk/debug, etc.). The previous rule auto-merged any patch/minor Dependabot PR; this rule auto-merges only when **all** of the following hold:

- The PR resolves a published security advisory (`cve-ids` is non-empty), AND
- The new version has been on npm for **at least 7 days** (manual cooldown — Dependabot's built-in `cooldown` does not apply to security updates), AND
- The bumped package is a **direct** dep (not a transitive `indirect`), AND
- The bump is patch or minor (majors still require manual review).

Anything that fails one of those conditions opens a PR but waits for a human.

## Files
- `.github/dependabot.yml` — new. `open-pull-requests-limit: 0` so we don't get routine weekly version bumps; only security PRs flow. Includes `cooldown` so that if version updates are ever turned on, they wait 7+ days. Also adds the same policy for `github-actions` deps.
- `.github/workflows/dependabot-auto-merge.yml` — replaces previous workflow. Adds an npm-registry publish-date check (manual cooldown) and tightens the `if` conditions on the merge step.

## Why
"Auto-merge any green Dependabot PR" was defensible 18 months ago. With recent compromised-package waves, the window between malicious publish and community detection (~24-72h) is exactly the window that auto-merge accelerates. Holding new releases for a week catches almost all of those before they land in `main`.

## Test plan
- [ ] Merge.
- [ ] Watch the next Dependabot security PR; confirm the `Check release age` step prints publish dates and decides correctly.
- [ ] Confirm a PR for a >7-day-old patch with a CVE auto-merges as before.
- [ ] Confirm a PR for a freshly-published version stays open with no auto-merge.