### PR TITLE
Enable routine version updates with cooldown; drop workflow cooldown for security PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -12,6 +11,5 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
     cooldown:
       default-days: 7

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,39 +16,9 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Check release age (manual cooldown)
-        id: cooldown
-        if: steps.meta.outputs.cve-ids != ''
-        run: |
-          set -euo pipefail
-          MIN_AGE_DAYS=7
-          # For grouped updates, dependency-names is comma-separated. Check the youngest.
-          IFS=',' read -ra PKGS <<< "${{ steps.meta.outputs.dependency-names }}"
-          version="${{ steps.meta.outputs.new-version }}"
-          youngest=99999
-          for raw in "${PKGS[@]}"; do
-            pkg=$(echo "$raw" | xargs)
-            published=$(curl -sf "https://registry.npmjs.org/${pkg}" | jq -r ".time[\"${version}\"] // empty")
-            if [ -z "$published" ]; then
-              echo "Could not look up publish date for ${pkg}@${version}; treating as too new."
-              youngest=0
-              break
-            fi
-            age=$(( ( $(date -u +%s) - $(date -u -d "$published" +%s) ) / 86400 ))
-            echo "${pkg}@${version} published ${age} days ago"
-            if [ "$age" -lt "$youngest" ]; then youngest=$age; fi
-          done
-          if [ "$youngest" -ge "$MIN_AGE_DAYS" ]; then
-            echo "ok=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ok=false" >> "$GITHUB_OUTPUT"
-            echo "Release younger than ${MIN_AGE_DAYS} days; leaving for manual review."
-          fi
-
-      - name: Enable auto-merge for security patches on direct deps
+      - name: Enable auto-merge for direct-dep security patches
         if: |
           steps.meta.outputs.cve-ids != '' &&
-          steps.cooldown.outputs.ok == 'true' &&
           (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
            steps.meta.outputs.update-type == 'version-update:semver-minor') &&
           startsWith(steps.meta.outputs.dependency-type, 'direct:')


### PR DESCRIPTION
## Summary

Refines the model from #33 based on this risk reasoning:

- **Security updates (CVE published):** the current version is *known* to be exploitable. Waiting 7 days trades certain exposure to a known threat for possible exposure to a rare hypothetical (a compromised replacement). Bad trade. Auto-merge ASAP.
- **Routine version updates:** current version is fine. Upgrading to a freshly-published version is the *only* way to be hit by a compromised release. Cooldown earns its keep here.

## Changes

**`.github/dependabot.yml`**
- Drop \`open-pull-requests-limit: 0\` from both ecosystems. Routine version updates are now enabled (default of 5 open PRs at a time per ecosystem), all subject to the existing 7-day cooldown.
- This also unblocks security PRs, which appear to have been collateral damage of \`limit: 0\` despite GitHub docs stating security has its own internal limit.

**\`.github/workflows/dependabot-auto-merge.yml\`**
- Remove the manual npm-registry publish-date check. Per [GitHub docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file): _"The cooldown option is only available for version updates, not security updates."_ — so cooldown for security PRs is intentionally absent at the platform level. We were re-implementing it; we no longer want to.
- Auto-merge condition unchanged otherwise: only direct-dep, patch/minor, CVE-driven Dependabot PRs auto-merge.

## What this gives us

| Update class | What happens |
|---|---|
| Security (\`cve-ids\` non-empty) | Opens immediately, auto-merges if direct + patch/minor + CI green |
| Routine version bump | Waits 7-14 days (cooldown), then opens, **manual review required** |
| Major-version security bump | Opens immediately, manual review required |
| Transitive dep | Opens, manual review required |

## Test plan
- [ ] Merge.
- [ ] Click "Check for updates" at https://github.com/ariessolutionsio/shop-assist/security/dependabot to force re-eval.
- [ ] Confirm the 99 alerts with available fix versions begin opening as PRs again.
- [ ] Confirm a fresh security PR auto-merges through the simplified workflow once \`build (18.x)\` is green.